### PR TITLE
Bump to Python 3.13 and expand tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# Sherlog — your build‑log whisperer
+# Sherlog — your build‑log whisperer 🕵️‍♂️
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Python >=3.9](https://img.shields.io/badge/python-%3E%3D3.9-blue)](#)
+[![Python >=3.13](https://img.shields.io/badge/python-%3E%3D3.13-blue)](#)
 [![Packaging: uv tools](https://img.shields.io/badge/packaging-uv%20tools-8A2BE2)](https://docs.astral.sh/uv/concepts/tools/)
 [![Tests: pytest](https://img.shields.io/badge/tests-pytest-green)](#)
 [![Status: experimental](https://img.shields.io/badge/status-experimental-orange)](#)
 
-Sherlog is a tiny, local‑first CLI that reads noisy build or install logs and tells you exactly what to do.
+Sherlog is a tiny, local‑first CLI that reads noisy build or install logs and tells you exactly what to do 😄.  
+Requires Python 3.13+ 🐍
 
-- Sniffs the real error from long logs.
-- Explains it with a local Small Language Model (Hugging Face) — or falls back to rule‑based hints.
-- Prints copy‑paste fixes per OS.
+- Sniffs the real error from long logs 🧐
+- Explains it with a local Small Language Model (Hugging Face) — or falls back to rule‑based hints 🤖
+- Prints copy‑paste fixes per OS 🛠️
 
 ## Install (global via `uv`)
 
@@ -87,7 +88,7 @@ sherlog examples/sample.log --model microsoft/phi-3-mini-4k-instruct --os ubuntu
 
 ## Contributing
 
-Contributions welcome! If you’d like to add rules, improve the CLI, or enhance docs:
+Contributions welcome! If you’d like to add rules, improve the CLI, or enhance docs, we'd love your help 😊:
 
 - Fork and create a feature branch.
 - Add or update tests for behavior changes (`pytest`).
@@ -97,17 +98,16 @@ Contributions welcome! If you’d like to add rules, improve the CLI, or enhance
 Local dev setup and tests:
 
 ```bash
-uv pip install -e '.[test]'
-uv run -m pytest -q
+uv python install 3.13  # one-time
+uv run -p 3.13 --extra test -m pytest -q
 ```
 
 ## Tests (pytest)
 
-Run tests locally with pytest. The simplest route is to install the project in editable mode with the `test` extra and then run pytest via `uv`:
+Run tests locally with pytest. The simplest route is to ensure Python 3.13 is available and run:
 
 ```bash
-uv pip install -e '.[test]'
-uv run -m pytest -q
+uv run -p 3.13 --extra test -m pytest -q
 ```
 
 ## Models (local SLMs)
@@ -133,8 +133,10 @@ See Hugging Face’s [SLM overview](https://huggingface.co/blog/jjokah/small-lan
 
 ## Thanks
 
-Inspired by countless hours debugging build logs and by the excellent local SLM ecosystem.
+Inspired by countless hours debugging build logs and by the excellent local SLM ecosystem 🙏
 
 ## License
 
-MIT
+MIT 🙂
+
+Happy debugging! 😄

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Sherlog — your build-log whisperer. Parse build logs and get ac
 readme = "README.md"
 license = {text = "MIT"}
 authors = [{name = "Maxence Bouvier", email = "maxence.bouvier.pro@gmail.com"}]
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 dependencies = [
   "regex>=2023.10.3",
   "rich>=13.7.0",

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,11 +1,74 @@
-from sherlog.rules import apply_rules, extract_failure_window
+from sherlog.rules import apply_rules, extract_failure_window, Finding
+from sherlog.cli import make_user_prompt, rules_only_text
+
+
 
 def test_compiler_rule():
     snippet = "building ext\nerror: command 'cc' failed: No such file or directory\n"
     findings = apply_rules(snippet, "debian")
     assert any(f.rule == "Missing C compiler" for f in findings)
 
+
 def test_window_extract():
     text = "\n".join([f"line {i}" for i in range(100)]) + "\nerror: something bad\n"
     snippet = extract_failure_window(text, window=20)
     assert "error:" in snippet
+
+
+def test_python_headers_rule():
+    snippet = "fatal error: Python.h: No such file or directory"
+    findings = apply_rules(snippet, "ubuntu")
+    assert any(f.rule == "Missing Python headers" for f in findings)
+
+
+def test_unsupported_python_rule():
+    snippet = "Requires-Python: >=3.14"
+    findings = apply_rules(snippet, "debian")
+    assert any(f.rule == "Unsupported Python version for wheel" for f in findings)
+
+
+def test_system_lib_rule():
+    snippet = "fatal error: openssl/ssl.h: No such file or directory"
+    findings = apply_rules(snippet, "debian")
+    assert any(
+        f.rule == "Missing system lib (e.g., libffi, openssl)" for f in findings
+    )
+
+
+def test_pkg_config_rule():
+    snippet = "pkg-config: command not found"
+    findings = apply_rules(snippet, "debian")
+    assert any(f.rule == "pkg-config missing" for f in findings)
+
+
+def test_cmake_rule():
+    snippet = "cmake: command not found"
+    findings = apply_rules(snippet, "debian")
+    assert any(f.rule == "CMake not found" for f in findings)
+
+
+def test_network_tls_rule():
+    snippet = "SSLError: TLSV1_ALERT_PROTOCOL_VERSION"
+    findings = apply_rules(snippet, "debian")
+    assert any(
+        f.rule == "Network / TLS issues fetching wheels" for f in findings
+    )
+
+
+def test_make_user_prompt_includes_findings():
+    finding = Finding(
+        rule="Missing C compiler", reason="No compiler", fix="install build-essential"
+    )
+    prompt = make_user_prompt("error", "ubuntu", "pip", [finding])
+    assert "Detected patterns" in prompt and "Missing C compiler" in prompt
+
+
+def test_rules_only_text_outputs_findings():
+    findings = [Finding(rule="Foo", reason="Bar", fix="Baz")]
+    text = rules_only_text(findings)
+    assert "Foo" in text and "Baz" in text
+
+
+def test_rules_only_text_no_findings():
+    text = rules_only_text([])
+    assert "No known patterns" in text


### PR DESCRIPTION
## Summary
- raise minimum Python to 3.13
- spice up README with emojis and updated dev instructions
- add broad unit tests for built-in log rules

## Testing
- `uv run -p /root/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13 --extra test -m pytest -q`
- `uv run -p /root/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13 --extra test -m sherlog.cli examples/sample.log --no-ml --os ubuntu`

------
https://chatgpt.com/codex/tasks/task_e_68c08dc31b1c8325a16dbaea633f4977