### PR TITLE
Document flash-attn GPU extras and ensure torch build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ uv tool install './.[ml]'
 # Force a compatible Python for the tool env if needed:
 # uv python install 3.12
 # uv tool install -p 3.12 './.[ml,ml-gpu]'
-
-# Optional GPU extras (FlashAttention) for advanced CUDA setups:
+#
+# The project declares torch as a build dependency for flash-attn, so `uv` will
+# pull in a matching `torch` during the wheel build. If using another installer,
+# install `torch` first or run with `--no-build-isolation`.
+#
 # This may compile native extensions and requires a matching CUDA/PyTorch toolchain.
 # If unsure, skip this or add later.
-# uv tool install './.[ml,ml-gpu]'
 
 # Ensure ~/.local/bin is in PATH (bash example):
 export PATH="$HOME/.local/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,13 @@ sherlog = "sherlog.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/sherlog"]
 
+[tool.uv]
+preview = true
+
 [tool.uv.extra-build-dependencies]
 # Ensure torch is available in the build env when building flash-attn wheels
 # (some versions attempt to import torch at build time but don't declare it).
-flash-attn = ["torch"]
+flash-attn = ["torch>=2.2,<3"]
 # Some package managers normalize the project name with underscores
-flash_attn = ["torch"]
+flash_attn = ["torch>=2.2,<3"]
 sherlog = ["hatchling"]


### PR DESCRIPTION
## Summary
- ensure flash-attn wheels build with torch by declaring it as an extra build dependency
- document GPU/flash-attn install steps and torch build requirement in README

## Testing
- `UV_PREVIEW=1 uv run -p 3.13 --extra test -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12effc23c8325ba40ed7a2adf4e99