### PR TITLE
Document flash-attn GPU extras and ensure torch build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ uv tool install './.[ml]'
 # FlashAttention and PyTorch GPU wheels are easiest with Python 3.10–3.12.
 # Force a compatible Python for the tool env if needed:
 # uv python install 3.12
-# uv tool install -p 3.12 './.[ml,ml-gpu]'
-
-# Optional GPU extras (FlashAttention) for advanced CUDA setups:
+# UV_PREVIEW=1 uv tool install -p 3.12 './.[ml,ml-gpu]'
+#
+# The torch build requirement is handled via uv's preview "extra build dependencies"
+# feature. Without `UV_PREVIEW=1`, `flash-attn` may fail to build with
+# `ModuleNotFoundError: No module named 'torch'`. If using another installer,
+# install `torch` first or run with `--no-build-isolation`.
+#
 # This may compile native extensions and requires a matching CUDA/PyTorch toolchain.
 # If unsure, skip this or add later.
-# uv tool install './.[ml,ml-gpu]'
 
 # Ensure ~/.local/bin is in PATH (bash example):
 export PATH="$HOME/.local/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,12 @@ sherlog = "sherlog.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/sherlog"]
 
+[tool.uv]
+preview = true
+
 [tool.uv.extra-build-dependencies]
 # Ensure torch is available in the build env when building flash-attn wheels
 # (some versions attempt to import torch at build time but don't declare it).
-flash-attn = ["torch"]
-# Some package managers normalize the project name with underscores
-flash_attn = ["torch"]
+flash-attn = ["torch>=2.2,<3"]
+# uv normalizes project names, so a single key covers `flash_attn`
 sherlog = ["hatchling"]


### PR DESCRIPTION
## Summary
- remove duplicate extra-build mapping for flash-attn
- note UV_PREVIEW flag required so uv installs torch before building flash-attn

## Testing
- `UV_PREVIEW=1 uv run -p 3.13 --extra test -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12effc23c8325ba40ed7a2adf4e99